### PR TITLE
correct f0 frame_length error

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -29,6 +29,7 @@ class TextMelLoader(torch.utils.data.Dataset):
             hparams.mel_fmax)
         self.sampling_rate = hparams.sampling_rate
         self.filter_length = hparams.filter_length
+        self.win_length = hparams.win_length
         self.hop_length = hparams.hop_length
         self.f0_min = hparams.f0_min
         self.f0_max = hparams.f0_max
@@ -83,7 +84,7 @@ class TextMelLoader(torch.utils.data.Dataset):
         melspec = torch.squeeze(melspec, 0)
 
         f0 = self.get_f0(audio.cpu().numpy(), self.sampling_rate,
-                         self.filter_length, self.hop_length, self.f0_min,
+                         self.win_length, self.hop_length, self.f0_min,
                          self.f0_max, self.harm_thresh)
         f0 = torch.from_numpy(f0)[None]
         f0 = f0[:, :melspec.size(1)]


### PR DESCRIPTION
The parameter "frame_length" in compute_f0 should be the "win_length" rather than the "filter_length". 
When filter_length > win_length, the f0 computation will be incorrect. 
As in mel computation, we first get the window with win_length and then pad it to filter_length.
In F0 computation, we should as well compute F0 within a win_length frame rather than filter_length frame.