### PR TITLE
Fixed CMUDict and ARPAbet conversion (p_arpabet is currently not used)

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -92,7 +92,7 @@ class TextMelLoader(torch.utils.data.Dataset):
 
     def get_text(self, text):
         text_norm = torch.IntTensor(
-            text_to_sequence(text, self.text_cleaners, self.cmudict))
+            text_to_sequence(text, self.text_cleaners, self.cmudict, self.p_arpabet))
         return text_norm
 
     def __getitem__(self, index):

--- a/text/__init__.py
+++ b/text/__init__.py
@@ -1,5 +1,5 @@
 """ from https://github.com/keithito/tacotron """
-import re
+import re, random
 from text import cleaners
 from text.symbols import symbols
 
@@ -20,7 +20,7 @@ def get_arpabet(word, dictionary):
     return word
 
 
-def text_to_sequence(text, cleaner_names, dictionary=None):
+def text_to_sequence(text, cleaner_names, dictionary=None, p_arpabet=0.0):
   '''Converts a string of text to a sequence of IDs corresponding to the symbols in the text.
 
     The text can optionally have ARPAbet sequences enclosed in curly braces embedded
@@ -43,7 +43,7 @@ def text_to_sequence(text, cleaner_names, dictionary=None):
     if not m:
       clean_text = _clean_text(text, cleaner_names)
       if cmudict is not None:
-        clean_text = [get_arpabet(w, dictionary) for w in clean_text.split(" ")]
+        clean_text = [get_arpabet(w, dictionary) if random.random() < p_arpabet else w for w in clean_text.split(" ")]
         for i in range(len(clean_text)):
             t = clean_text[i]
             if t.startswith("{"):

--- a/text/cmudict.py
+++ b/text/cmudict.py
@@ -46,9 +46,9 @@ def _parse_cmudict(file):
   cmudict = {}
   for line in file:
     if len(line) and (line[0] >= 'A' and line[0] <= 'Z' or line[0] == "'"):
-      parts = line.split('  ')
+      parts = re.split('\s+', line.strip())
       word = re.sub(_alt_re, '', parts[0])
-      pronunciation = _get_pronunciation(parts[1])
+      pronunciation = _get_pronunciation(parts[1:])
       if pronunciation:
         if word in cmudict:
           cmudict[word].append(pronunciation)
@@ -58,8 +58,7 @@ def _parse_cmudict(file):
 
 
 def _get_pronunciation(s):
-  parts = s.strip().split(' ')
-  for part in parts:
+  for part in s:
     if part not in _valid_symbol_set:
       return None
-  return ' '.join(parts)
+  return ' '.join(s)


### PR DESCRIPTION
p_arpabet was never used when generating sequences. Also added a little bit more robustness to CMUDict to be spacing-agnostic.

I also would recommend a consistent EOS symbol at the end of every generated sequence but did not include that in this PR. I can make another for that if needed, its a super easy change but would break model compatibility.