### PR TITLE
Replace split word_tokenize to deal with punctuations.

### DIFF
--- a/text/__init__.py
+++ b/text/__init__.py
@@ -3,6 +3,7 @@ import re
 import random
 from text import cleaners
 from text.symbols import symbols
+from nltk.tokenize import word_tokenize
 
 
 # Mappings from symbol to numeric ID and vice versa:
@@ -46,7 +47,7 @@ def text_to_sequence(text, cleaner_names, dictionary=None, p_arpabet=1.0):
       if cmudict is not None:
         clean_text = [get_arpabet(w, dictionary) 
                       if random.random() < p_arpabet else w 
-                      for w in clean_text.split(" ")]
+                      for w in word_tokenize(clean_text)]
 
         for i in range(len(clean_text)):
             t = clean_text[i]


### PR DESCRIPTION
The previous line uses `split` by splitting blanks, to get a list of words from a character string. With this approach, words concatenated with punctuation are considered a word, which results in the out-of-vocabulary problem for the CMU dictionary. I got the following sentence below with the previous implementation.

"{L AO1 NG} {N EH1 R OW0} {R UW1 M Z} -- {W AH1 N} thirty-six feet, {S IH1 K S} {T W EH1 N T IY0 TH R IY2} feet, {AH0 N D} {DH AH0} {EY1 T TH} eighteen,"

 So, I suggest to use the NLTK tokenizer to split punctuation from words.