### PR TITLE
Fix mel inputs passed to GST Reference Encoder

### DIFF
--- a/model.py
+++ b/model.py
@@ -601,7 +601,7 @@ class Tacotron2(nn.Module):
         embedded_inputs = self.embedding(inputs).transpose(1, 2)
         embedded_text = self.encoder(embedded_inputs, input_lengths)
         embedded_speakers = self.speaker_embedding(speaker_ids)[:, None]
-        embedded_gst = self.gst(targets, output_lengths)
+        embedded_gst = self.gst(targets.transpose(1, 2), output_lengths)
         embedded_gst = embedded_gst.repeat(1, embedded_text.size(1), 1)
         embedded_speakers = embedded_speakers.repeat(1, embedded_text.size(1), 1)
 

--- a/modules.py
+++ b/modules.py
@@ -58,6 +58,7 @@ class ReferenceEncoder(nn.Module):
         self.ref_enc_gru_size = hp.ref_enc_gru_size
 
     def forward(self, inputs, input_lengths=None):
+        assert inputs.size(-1) % self.n_mel_channels == 0
         out = inputs.view(inputs.size(0), 1, -1, self.n_mel_channels)
         for conv, bn in zip(self.convs, self.bns):
             out = conv(out)


### PR DESCRIPTION
In the current implementation, mel inputs passed to GST module (`targets`) have shape `[B, n_mel_channels, T_out]` and are reshaped to `[B, 1, T_out, n_mel_channels]` by GST Reference Encoder. As a result, Reference Encoder works not with original spectrograms.

This PR fixes the shape of GST inputs and adds an additional inputs shape check in `ReferenceEncoder`.